### PR TITLE
[ECO-879] Redirect to login when the user wants to logout

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -2,7 +2,7 @@
 import R from 'ramda';
 import firebase from '../services/firebase';
 import { getAuthToken, getAuthTokenUser } from '../services/api';
-import { saveAuthToken } from '../services/localStorage';
+import { saveAuthToken, saveState } from '../services/localStorage';
 import { logIn, logOut } from './currentUser';
 import { setSuccess, resetAlert, setInfo } from './alert';
 
@@ -52,7 +52,9 @@ const signIn: ThunkActionCreator = ({ email, password }: AuthCredentials): Thunk
 const signOut: ThunkActionCreator = (): Thunk =>
   (dispatch: Dispatch) => {
     dispatch(logOut());
-    firebase.auth().signOut();
+    // We need to ensure the localstorage is updated ASAP
+    saveState({ currentUser: null });
+    firebase.auth().signOut().then((): void => (window.location.href = '/'));
   };
 
 const resetPassword: ThunkActionCreator = ({ email }: AuthCredentials): Thunk =>

--- a/src/actions/currentUser.js
+++ b/src/actions/currentUser.js
@@ -20,7 +20,6 @@ const logIn: ThunkActionCreator = (userId: string): Thunk =>
 const logOut: ThunkActionCreator = (): Thunk =>
   (dispatch: Dispatch) => {
     dispatch(setCurrentUser(null));
-    browserHistory.push('/');
   };
 
 module.exports = {

--- a/src/actions/producer.js
+++ b/src/actions/producer.js
@@ -421,7 +421,9 @@ const connectBroadcast: ThunkActionCreator = (event: BroadcastEvent): Thunk =>
     const credentials = R.pick(credentialProps, await getAdminCredentials(event.id));
 
     // Register the producer in firebase
-    firebase.auth().onAuthStateChanged(async (): AsyncVoid => {
+    firebase.auth().onAuthStateChanged(async (user: AuthState): AsyncVoid => {
+      if (!user) return;
+      
       const base = `activeBroadcasts/${event.adminId}/${event.fanUrl}`;
       const query = await firebase.database().ref(`${base}/producerActive`).once('value');
       const producerActive = query.val();


### PR DESCRIPTION
There was a bug during a show when the producer wants to logout.

The reason of the bug was that firebase wasn't updated correctly and we we're not validating if the user is or not logged in inside this listener: firebase.auth().onAuthStateChanged

The cleaner solution was to do a classic window.location.href redirection to the login in order to ensure that firebase is correctly updated, and all the listeners and OT connection are destroyed.