### PR TITLE
[ECO-294] Validate if the private call fanId belongs to the current fan

### DIFF
--- a/src/actions/fan.js
+++ b/src/actions/fan.js
@@ -451,7 +451,7 @@ const monitorPrivateCall: ThunkActionCreator = (fanId: UserId): Thunk =>
 
       // A new call
       if (R.isNil(currentState) && !!update) {
-        if (R.equals(fanType, update.isWith)) {
+        if (R.equals(fanType, update.isWith) && R.equals(fanId, update.fanId)) {
           // If the call is with us, we need to subcribe only to producer audio
           opentok.unsubscribeAll('stage', true);
           // const instance = onStage ? 'stage' : 'backstage';


### PR DESCRIPTION
When the producer starts a private call with an active fan, the rest of fans erroneously think they have also a private call with the producer. So in that moment all the fans stop subscribing audio from the onstage session, and try to subscribe the producer. Only the real fan that was called can hear to the producer. 

The solution is to validate if me fanId is the same as the one is in firebase inside the privateCall node. If it's different it means that I'm not that fan, so I don't need to unsubscribe onstage audio.