### PR TITLE
Bug fix: Ensure the hidden chat don't block the producer

### DIFF
--- a/src/components/Common/Chat.css
+++ b/src/components/Common/Chat.css
@@ -8,6 +8,8 @@
 
 .Chat.hidden {
     visibility: hidden;
+    width: 1px;
+    height: 1px;
 }
 
 .ChatHeader {


### PR DESCRIPTION
This is a minor fix. When the producer opens the chat for celebrity and host, and then close one of them, it won't be possible to press on the icons behind the chat since the div is hidden but it keep the width and height.