### PR TITLE
[ECO-912] Redirect if an admin tries to open an event that doesn't belong to him

### DIFF
--- a/src/actions/producer.js
+++ b/src/actions/producer.js
@@ -493,6 +493,13 @@ const initializeBroadcast: ThunkActionCreator = (eventId: EventId): Thunk =>
   async (dispatch: Dispatch, getState: GetState): AsyncVoid => {
     try {
       const event = R.path(['events', 'map', eventId], getState()) || await getEvent(eventId);
+
+      // Validate if the event requested belongs to the current admin
+      if (!R.equals(firebase.auth().currentUser.uid, event.adminId)) {
+        browserHistory.replace('/admin');
+        return;
+      }
+
       const actions = [
         updateStatus(eventId, 'preshow'),
         connectBroadcast(event),


### PR DESCRIPTION
This PR validates if the current logged in admin has access to an event. If not, we're going to redirect him to the dashboard.