### PR TITLE
Display the manage users button only to superadmins

### DIFF
--- a/src/components/Dashboard/components/DashboardHeader.js
+++ b/src/components/Dashboard/components/DashboardHeader.js
@@ -48,9 +48,12 @@ class DashboardHeader extends Component {
           <Link to="/events/new">
             <button className="btn white control"><Icon name="plus" />Add New Event</button>
           </Link>
-          <Link to="/users">
-            <button className="btn white control"><Icon name="user" />Manage Users</button>
-          </Link>
+          {
+            currentUser.superAdmin &&
+            <Link to="/users">
+              <button className="btn white control"><Icon name="user" />Manage Users</button>
+            </Link>
+          }
         </div>
       </div>
     );


### PR DESCRIPTION
The manage users button should be only displayed to superadmins.