### PR TITLE
Bug fix: Add error alert if the credentials are wrong

### DIFF
--- a/src/actions/producer.js
+++ b/src/actions/producer.js
@@ -2,7 +2,7 @@
 import R from 'ramda';
 import { browserHistory } from 'react-router';
 import { updateStatus } from './events';
-import { setInfo, setBlockUserAlert, setCameraError } from './alert';
+import { setInfo, setBlockUserAlert, setCameraError, resetAlert } from './alert';
 import { getEvent, getAdminCredentials, getEventWithCredentials } from '../services/api';
 import firebase from '../services/firebase';
 import {
@@ -178,7 +178,24 @@ const opentokConfig = (dispatch: Dispatch, getState: GetState, userCredentials: 
 const connectToInteractive: ThunkActionCreator = (userCredentials: UserCredentials): Thunk =>
   async (dispatch: Dispatch, getState: GetState): AsyncVoid => {
     const instances: CoreInstanceOptions[] = opentokConfig(dispatch, getState, userCredentials);
-    opentok.init(instances);
+    try {
+      opentok.init(instances);
+    } catch (error) {
+      const options = (): AlertPartialOptions => ({
+        title: 'Error',
+        text: "There's an error with your Opentok credentials. Please check your credentials and try again.",
+        showConfirmButton: true,
+        html: true,
+        type: 'error',
+        allowEscapeKey: false,
+        onConfirm: () => {
+          browserHistory.push('/admin');
+          dispatch(resetAlert());
+        },
+      });
+      dispatch(setInfo(options()));
+    }
+
     try {
       analytics.log(logAction.producerConnects, logVariation.attempt);
       await opentok.connect(['stage', 'backstage']);
@@ -424,7 +441,6 @@ const connectBroadcast: ThunkActionCreator = (event: BroadcastEvent): Thunk =>
     // Register the producer in firebase
     firebase.auth().onAuthStateChanged(async (user: AuthState): AsyncVoid => {
       if (!user) return;
-      
       const base = `activeBroadcasts/${event.adminId}/${event.fanUrl}`;
       const query = await firebase.database().ref(`${base}/producerActive`).once('value');
       const producerActive = query.val();

--- a/src/components/Users/components/EditUser.js
+++ b/src/components/Users/components/EditUser.js
@@ -8,7 +8,6 @@ import Icon from 'react-fontawesome';
 import uuid from 'uuid';
 import './EditUser.css';
 import { createNewUser, updateUserRecord } from '../../../actions/users';
-import { setCurrentUser } from '../../../actions/currentUser';
 
 const emptyUser: UserFormData = {
   email: '',
@@ -32,8 +31,7 @@ type DispatchProps = {
   updateCurrentUser: UserFormData => void,
   createUser: UserFormData => Promise<void>
 };
-type InitialProps = { adminId: string };
-type Props = BaseProps & DispatchProps & InitialProps;
+type Props = BaseProps & DispatchProps;
 class EditUser extends Component {
 
   props: Props;
@@ -84,7 +82,7 @@ class EditUser extends Component {
     this.setState({ submissionAttemped: true });
     if (this.hasErrors()) { return; }
     let userData = R.prop('fields', this.state);
-    const { newUser, toggleEditPanel, createUser, updateUser, adminId } = this.props;
+    const { newUser, toggleEditPanel, createUser, updateUser } = this.props;
     const user = R.defaultTo({}, this.props.user);
     const initial = R.pick(formFields, user);
 
@@ -96,9 +94,6 @@ class EditUser extends Component {
         userData = R.assoc('id', user.id, userData);
         userData = !userData.otApiKey && !userData.otSecret ? R.omit(['otApiKKey', 'otSecret'], userData) : userData;
         await updateUser(userData);
-        if (adminId === user.id) {
-          this.props.updateCurrentUser(userData);
-        }
         toggleEditPanel();
       }
     } else {
@@ -198,20 +193,12 @@ class EditUser extends Component {
     );
   }
 }
-
-const mapStateToProps = (state: State, ownProps: InitialProps): BaseProps => ({
-  adminId: R.path(['params', 'adminId'], ownProps),
-});
-
 const mapDispatchToProps: MapDispatchToProps<DispatchProps> = (dispatch: Dispatch): DispatchProps =>
   ({
     updateUser: (userData: UserFormData) => {
       dispatch(updateUserRecord(userData));
     },
     createUser: async (userData: UserFormData): AsyncVoid => dispatch(createNewUser(userData)),
-    updateCurrentUser: (userData: UserFormData) => {
-      dispatch(setCurrentUser(userData));
-    },
   });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EditUser));
+export default withRouter(connect(null, mapDispatchToProps)(EditUser));

--- a/src/services/opentok.js
+++ b/src/services/opentok.js
@@ -49,7 +49,11 @@ const init = (instancesToCreate: CoreInstanceOptions[]) => {
     listeners[name] = eventListeners;
     options[name] = opentokOptions;
   };
-  R.forEach(createCoreInstance, instancesToCreate);
+  try {
+    R.forEach(createCoreInstance, instancesToCreate);
+  } catch (error) {
+    throw error;
+  }
 };
 
 /**


### PR DESCRIPTION
There is a bug when the admin changes the OT credentials and tries to open an event created with old credentials.
We're adding in this PR an alert to catch the error.

Also, when the admin changes his profile we were updating the current user in the global state before the confirmation from the backend.