### PR TITLE
[ECO-1574] Add allow camera and mic on iframe

### DIFF
--- a/public/embed.js
+++ b/public/embed.js
@@ -56,6 +56,7 @@ window.IBSApp = {
     iframe.width = config.width;
     iframe.height = config.height;
     iframe.scrolling = 'no';
+    iframe.allow = 'microphone; camera';
     iframe.onload = function() {
       iframe.contentWindow.document.body.style.background = '#262626';
     }


### PR DESCRIPTION
Regarding https://support.tokbox.com/hc/en-us/articles/115001864070-Chrome-64-iFrame-behavior-change we need to add `"allow="microphone; camera"` on the iframes.