### PR TITLE
Refactor firebase references

### DIFF
--- a/src/actions/broadcast.js
+++ b/src/actions/broadcast.js
@@ -203,7 +203,6 @@ const startHeartBeat: ThunkActionCreator = (userType: UserType): Thunk =>
   const { adminId, fanUrl } = event;
   const ref = firebase.database().ref(`activeBroadcasts/${adminId}/${fanUrl}/${userType}HeartBeat`);
   const updateHeartbeat = (): void => ref.set(moment.utc().valueOf());
-  updateHeartbeat();
   heartBeatInterval = setInterval(() => {
     updateHeartbeat();
   }, heartBeatTime * 1000);


### PR DESCRIPTION
We have many firebase references pointing to the same path. We can refactor this into one ref.
Beside, when the producer sets the producerActive to true, I'm using the same moment to update the heartbeat.