### PR TITLE
Fix private call between Producer and celebrity / host 

### DIFF
--- a/flowtypes/broadcast.js
+++ b/flowtypes/broadcast.js
@@ -165,6 +165,7 @@ declare type ChatState = {
  */
 
 declare type BroadcastAction =
+  { type: 'EVENT_STARTED', eventStarted: boolean } |
   { type: 'FAN_TRANSITION', fanTransition: boolean } |
   { type: 'SET_BROADCAST_EVENT', event: BroadcastEvent } |
   { type: 'RESET_BROADCAST_EVENT' } |

--- a/src/actions/celebrityHost.js
+++ b/src/actions/celebrityHost.js
@@ -304,6 +304,8 @@ const initializeBroadcast: ThunkActionCreator = ({ adminId, userType, userUrl }:
 
       // Get the eventData
       const eventData = R.path(['broadcast', 'event'], getState());
+      const { apiKey, stageSessionId, status } = eventData;
+      analytics = new Analytics(window.location.origin, stageSessionId, null, apiKey);
 
       // Register the celebrity/host in firebase
       firebase.auth().onAuthStateChanged(async (user: InteractiveFan): AsyncVoid => {
@@ -325,9 +327,6 @@ const initializeBroadcast: ThunkActionCreator = ({ adminId, userType, userUrl }:
             } catch (error) {
               console.log('Failed to create the record: ', error); // eslint-disable-line no-console
             }
-            /* Connect to the session */
-            const { apiKey, stageSessionId, status } = eventData;
-            analytics = new Analytics(window.location.origin, stageSessionId, null, apiKey);
             if (status !== 'closed') {
               dispatch(startHeartBeat(userType));
             }

--- a/src/components/Broadcast/CelebrityHost/CelebrityHost.css
+++ b/src/components/Broadcast/CelebrityHost/CelebrityHost.css
@@ -33,6 +33,15 @@ body {
   right: 15px;
 }
 
+.CelebrityHostBody.notStarted {
+  justify-content: center;
+  align-items: center
+}
+
+.CelebrityHostBody .btn.action.green {
+  position: absolute;
+}
+
 /* Embed styles */
 .CelebrityHostEmbed {
   background: #262626;

--- a/src/components/Broadcast/CelebrityHost/components/CelebrityHostBody.js
+++ b/src/components/Broadcast/CelebrityHost/components/CelebrityHostBody.js
@@ -11,12 +11,14 @@ type Props = {
   status: EventStatus,
   endImage?: EventImage,
   participants: null | BroadcastParticipants, // publishOnly => null
-  userType: 'host' | 'celebrity'
+  userType: 'host' | 'celebrity',
+  eventStarted: boolean,
+  startEvent: Unit
 };
 const CelebrityHostBody = (props: Props): ReactComponent => {
-  const { status, endImage, participants, userType } = props;
+  const { status, endImage, participants, userType, eventStarted, startEvent } = props;
   const isClosed = status === 'closed';
-  const imgClass = classNames('CelebrityHostBody', { withStreams: !isClosed });
+  const imgClass = classNames('CelebrityHostBody', { withStreams: !isClosed, notStarted: !eventStarted  });
   const endImageUrl = endImage ? endImage.url : null;
   return (
     <div className={imgClass}>
@@ -25,6 +27,7 @@ const CelebrityHostBody = (props: Props): ReactComponent => {
           <img src={endImageUrl || defaultImg} alt="event ended" className="closeImage" />
         </div>
       }
+      { !isClosed && !eventStarted && <button className="btn action green " onClick={startEvent}>START</button> }
       { !isClosed && userTypes.map((type: ParticipantType): ReactComponent =>
         <VideoHolder
           key={`videoStream${type}`}

--- a/src/components/Broadcast/CelebrityHost/components/CelebrityHostBody.js
+++ b/src/components/Broadcast/CelebrityHost/components/CelebrityHostBody.js
@@ -27,7 +27,7 @@ const CelebrityHostBody = (props: Props): ReactComponent => {
           <img src={endImageUrl || defaultImg} alt="event ended" className="closeImage" />
         </div>
       }
-      { !isClosed && !eventStarted && <button className="btn action green " onClick={startEvent}>START</button> }
+      { !isClosed && !eventStarted && <button className="btn action green " onClick={startEvent}>JOIN SESSION</button> }
       { !isClosed && userTypes.map((type: ParticipantType): ReactComponent =>
         <VideoHolder
           key={`videoStream${type}`}

--- a/src/components/Broadcast/CelebrityHost/components/CelebrityHostHeader.js
+++ b/src/components/Broadcast/CelebrityHost/components/CelebrityHostHeader.js
@@ -12,10 +12,11 @@ type Props = {
   togglePublishOnly: boolean => void,
   publishOnlyEnabled: boolean,
   disconnected: boolean,
-  privateCall: PrivateCallState // eslint-disable-line react/no-unused-prop-types
+  privateCall: PrivateCallState, // eslint-disable-line react/no-unused-prop-types
+  eventStarted: boolean
 };
 const CelebrityHostHeader = (props: Props): ReactComponent => {
-  const { userType, name, status, togglePublishOnly, publishOnlyEnabled, disconnected } = props;
+  const { userType, name, status, togglePublishOnly, publishOnlyEnabled, disconnected, eventStarted } = props;
   const btnClass = classNames('btn action', { red: !publishOnlyEnabled }, { green: publishOnlyEnabled });
   const privateCallWith = R.path(['privateCall', 'isWith'], props);
   const inPrivateCall = R.equals(userType, privateCallWith);
@@ -25,7 +26,7 @@ const CelebrityHostHeader = (props: Props): ReactComponent => {
       <div className="CelebrityHostHeader-main">
         <div>
           <h4>{name}<sup>{status === 'notStarted' ? 'NOT STARTED' : status}</sup></h4>
-          { status !== 'closed' && !disconnected &&
+          { status !== 'closed' && !disconnected && eventStarted &&
             <div>
               <button className={btnClass} onClick={togglePublishOnly}>PUBLISH ONLY {publishOnlyEnabled ? 'ON' : 'OFF'}</button>
             </div>

--- a/src/reducers/broadcast.js
+++ b/src/reducers/broadcast.js
@@ -62,6 +62,7 @@ const initialState = (): BroadcastState => ({
   disconnected: false,
   elapsedTime: '--:--:--',
   fanTransition: false,
+  eventStarted: false,
 });
 
 const activeFansUpdate = (activeFans: ActiveFans, update: ActiveFanMap): ActiveFans => {
@@ -89,6 +90,8 @@ const updateFanOrder = (activeFans: ActiveFans, update: ActiveFanOrderUpdate): A
 
 const broadcast = (state: BroadcastState = initialState(), action: BroadcastAction): BroadcastState => {
   switch (action.type) {
+    case 'EVENT_STARTED':
+      return R.assoc('eventStarted', action.eventStarted, state);
     case 'FAN_TRANSITION':
       return R.assoc('fanTransition', action.fanTransition, state);
     case 'SET_RECONNECTING':


### PR DESCRIPTION
Regarding the new policy in Chrome 71 about the AudioContext API, we need to add a user gesture before subscribe the audio of a stream. Because of this new policy, the private call between the producer and the celebrity/host doesn't work when the celebrity/host opens the event page for the first time.

This PR simply adds a START button to the Host/Celebrity component that will init the OT connection.


